### PR TITLE
Add batchnorm3d benchmark

### DIFF
--- a/demos/benchmarks/batchnormalization3d_benchmark.ts
+++ b/demos/benchmarks/batchnormalization3d_benchmark.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+// tslint:disable-next-line:max-line-length
+import {Array1D, Array3D, NDArrayMathCPU } from '../deeplearn';
+
+import {BenchmarkTest} from './benchmark';
+
+export class BatchNormalization3DCPUBenchmark extends BenchmarkTest {
+  async run(size: number, option: string): Promise<number> {
+    const math = new NDArrayMathCPU();
+    const x = Array3D.randUniform([size, size, size], -1, 1);
+    const mean = Array1D.new([1, 2]);
+    const variance = Array1D.new([2, 3]);
+    const varianceEpsilon = .001;
+    const start = performance.now();
+    math.batchNormalization3D(
+        x, mean, variance, varianceEpsilon, undefined, undefined);
+    const end = performance.now();
+
+    return new Promise<number>((resolve, reject) => {
+      resolve(end - start);
+    });
+  }
+}

--- a/demos/benchmarks/math-benchmark-run-groups.ts
+++ b/demos/benchmarks/math-benchmark-run-groups.ts
@@ -16,6 +16,8 @@
  */
 
 import {BenchmarkRun, BenchmarkRunGroup} from './benchmark';
+// tslint:disable-next-line:max-line-length
+import {BatchNormalization3DCPUBenchmark} from './batchnormalization3d_benchmark';
 import {ConvBenchmarkParams, ConvGPUBenchmark} from './conv_benchmarks';
 // tslint:disable-next-line:max-line-length
 import {ConvTransposedBenchmarkParams, ConvTransposedGPUBenchmark} from './conv_transposed_benchmarks';
@@ -40,6 +42,18 @@ export function getRunGroups(): BenchmarkRunGroup[] {
     benchmarkRuns: [
       new BenchmarkRun('mulmat_gpu', new MatmulGPUBenchmark()),
       new BenchmarkRun('mulmat_cpu', new MatmulCPUBenchmark())
+    ],
+    params: {}
+  });
+
+  groups.push({
+    name: 'Batch Normaliztion 3D:',
+    min: 0,
+    max: 512,
+    stepSize: 64,
+    stepToSizeTransformation: (step: number) => Math.max(1, step),
+    benchmarkRuns: [
+      new BenchmarkRun('batchnorm_cpu', new BatchNormalization3DCPUBenchmark())
     ],
     params: {}
   });


### PR DESCRIPTION
Adding benchmark for `math.batchNormalization3D`.

### todo
- [x] cpu
- [ ] gpu
- [ ] best way to calc mean and variance